### PR TITLE
Use ContractScan for multichain deployment links

### DIFF
--- a/docs/addresses.md
+++ b/docs/addresses.md
@@ -13,7 +13,7 @@ The EntryPoint address is the same on all EVM networks.
 
 | Name       | Address                                        | Version                                                                             |
 |------------|------------------------------------------------|-------------------------------------------------------------------------------------|
-| EntryPoint | [0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789](https://blockscan.com/address/0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789) | 0.6.0 |
+| EntryPoint | [0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789](https://contractscan.xyz/contract/0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789) | 0.6.0 |
 
 ## TrueWallet Smart Account
 
@@ -21,9 +21,9 @@ The TrueWallet Smart Account addresses are the same on all EVM networks.
 
 | Name             | Address                                        | Version |
 |------------------|------------------------------------------------|---------|
-| Implementation   | [0x69F93bec57dc6464C2135f65F76062d88e037cB8](https://blockscan.com/address/0x69F93bec57dc6464C2135f65F76062d88e037cB8) | 1.0.0   |
-| Factory          | [0x5137F38ACa8572638E031710A806944480540271](https://blockscan.com/address/0x5137F38ACa8572638E031710A806944480540271) | 1.0.0   |
-| Contract Manager | [0x1C04d3Fd1761b29F7b56D2202130750c1DcA4281](https://blockscan.com/address/0x1C04d3Fd1761b29F7b56D2202130750c1DcA4281) | 1.0.0   |
+| Implementation   | [0x69F93bec57dc6464C2135f65F76062d88e037cB8](https://contractscan.xyz/contract/0x69F93bec57dc6464C2135f65F76062d88e037cB8) | 1.0.0   |
+| Factory          | [0x5137F38ACa8572638E031710A806944480540271](https://contractscan.xyz/contract/0x5137F38ACa8572638E031710A806944480540271) | 1.0.0   |
+| Contract Manager | [0x1C04d3Fd1761b29F7b56D2202130750c1DcA4281](https://contractscan.xyz/contract/0x1C04d3Fd1761b29F7b56D2202130750c1DcA4281) | 1.0.0   |
 
 ## TrueWallet Smart Account Modules
 
@@ -31,5 +31,5 @@ The TrueWallet Smart Account Modules addresses are the same on all EVM networks.
 
 | Name                   | Address                                        | Version |
 |------------------------|------------------------------------------------|---------|
-| Security Module        | [0x559103Ecd6cA2a0b92c973a7783dd83B9d7980ee](https://blockscan.com/address/0x559103Ecd6cA2a0b92c973a7783dd83B9d7980ee) | 1.0.0   |
-| Social Recovery Module | [0x929BAF181bFE97F59ecc22c3EFd33c0D9334380F](https://blockscan.com/address/0x929BAF181bFE97F59ecc22c3EFd33c0D9334380F) | 1.0.0   |
+| Security Module        | [0x559103Ecd6cA2a0b92c973a7783dd83B9d7980ee](https://contractscan.xyz/contract/0x559103Ecd6cA2a0b92c973a7783dd83B9d7980ee) | 1.0.0   |
+| Social Recovery Module | [0x929BAF181bFE97F59ecc22c3EFd33c0D9334380F](https://contractscan.xyz/contract/0x929BAF181bFE97F59ecc22c3EFd33c0D9334380F) | 1.0.0   |


### PR DESCRIPTION
Replaces Blockscan with ContractScan. The latter only highlights the networks where the code is actually deployed (vs those that have no code but some state e.g. balance), supports over 100 networks (vs 50ish), and is open-source.

> Disclaimer: author of ContractScan
